### PR TITLE
DvMap_A4.svg experimental update

### DIFF
--- a/delta_v_map_vanilla/DvMap_A4.svg
+++ b/delta_v_map_vanilla/DvMap_A4.svg
@@ -16,7 +16,7 @@
    width="210mm"
    height="297mm"
    viewBox="0 0 744.09449 1052.3622"
-   sodipodi:docname="DvMap_A4.svg"
+   sodipodi:docname="mapmap.svg"
    inkscape:export-filename="./DvMap_A4.png"
    inkscape:export-xdpi="300"
    inkscape:export-ydpi="300">
@@ -492,17 +492,17 @@
      guidetolerance="10"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:window-width="1680"
-     inkscape:window-height="987"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
      id="namedview4138"
      showgrid="false"
      units="mm"
      inkscape:snap-center="true"
      inkscape:snap-bbox="false"
      inkscape:object-nodes="true"
-     inkscape:zoom="3.0027686"
-     inkscape:cx="258.32939"
-     inkscape:cy="429.79662"
+     inkscape:zoom="1.061639"
+     inkscape:cx="346.00744"
+     inkscape:cy="622.21876"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
@@ -674,19 +674,19 @@
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc" />
   <path
-     style="opacity:1;fill:none;fill-opacity:1;stroke:#b26431;stroke-width:17.71653557;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="opacity:1;fill:none;fill-opacity:1;stroke:#d38d5f;stroke-width:17.71653557;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="m 332.29226,688.36514 -3e-5,-38.56318"
      id="path9063"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc" />
   <path
-     style="opacity:1;fill:none;fill-opacity:1;stroke:#b26431;stroke-width:17.71653557;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="opacity:1;fill:none;fill-opacity:1;stroke:#d38d5f;stroke-width:17.71653557;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 332.29223,649.80196 280.36538,597.82157"
      id="path9061"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc" />
   <path
-     style="opacity:1;fill:none;fill-opacity:1;stroke:#b26431;stroke-width:17.71653557;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="opacity:1;fill:none;fill-opacity:1;stroke:#d38d5f;stroke-width:17.71653557;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="m 269.64613,597.82883 -171.2984,0"
      id="path9055"
      inkscape:connector-curvature="0"
@@ -779,11 +779,16 @@
        sodipodi:role="line"
        id="tspan5854"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.87999916px;font-family:Aller;-inkscape-font-specification:'Aller, Bold';fill:#000000">Eve</tspan><tspan
-       y="534.36096"
+       y="530.12927"
        x="76.298401"
        sodipodi:role="line"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080"
-       id="tspan4721">15850</tspan></text>
+       id="tspan4721">15850</tspan><tspan
+       y="545.75427"
+       x="76.298401"
+       sodipodi:role="line"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#b3b3b3"
+       id="tspan3929">1y 380d</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.87999916px;line-height:125%;font-family:Aller;-inkscape-font-specification:'Aller, Bold';text-align:end;writing-mode:lr-tb;text-anchor:end;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.48031497;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -798,9 +803,14 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.87999916px;font-family:Aller;-inkscape-font-specification:'Aller, Bold';fill:#000000">Moho</tspan><tspan
        sodipodi:role="line"
        x="76.291283"
-       y="625.03937"
+       y="620.80768"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080"
-       id="tspan4726">8390</tspan></text>
+       id="tspan4726">8390</tspan><tspan
+       sodipodi:role="line"
+       x="76.291283"
+       y="636.43268"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#b3b3b3"
+       id="tspan3925">135d</tspan></text>
   <text
      sodipodi:linespacing="125%"
      id="text4887"
@@ -848,7 +858,12 @@
        x="76.517578"
        sodipodi:role="line"
        id="tspan5850"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080">6540</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080">6540</tspan><tspan
+       y="404.06842"
+       x="76.517578"
+       sodipodi:role="line"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#b3b3b3"
+       id="tspan3931">2y 54d</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.87999916px;line-height:125%;font-family:Aller;-inkscape-font-specification:'Aller, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.48031497;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -864,7 +879,12 @@
        x="673.40424"
        y="69.005806"
        id="tspan5888"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080">6680</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080">6680</tspan><tspan
+       sodipodi:role="line"
+       x="673.40424"
+       y="84.630806"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#b3b3b3"
+       id="tspan3937">1y 84d</tspan></text>
   <text
      sodipodi:linespacing="125%"
      id="text4903"
@@ -1726,13 +1746,13 @@
      sodipodi:linespacing="125%"
      id="text4703-1"
      y="512.66394"
-     x="128.67108"
+     x="134.66554"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Aller;-inkscape-font-specification:Aller;text-align:justify;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.48031497;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      xml:space="preserve"><tspan
        y="512.66394"
-       x="128.67108"
+       x="134.66554"
        id="tspan4705-3"
-       sodipodi:role="line">10k</tspan></text>
+       sodipodi:role="line">9k</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Aller;-inkscape-font-specification:Aller;text-align:justify;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.48031497;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -2332,7 +2352,12 @@
        x="673.45496"
        sodipodi:role="line"
        id="tspan5880"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080">7480</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080">7480</tspan><tspan
+       y="726.97461"
+       x="673.45496"
+       sodipodi:role="line"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#b3b3b3"
+       id="tspan3935">1y 245d</tspan></text>
   <use
      x="0"
      y="0"
@@ -2479,7 +2504,12 @@
        x="678.52185"
        sodipodi:role="line"
        id="tspan5886"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080">22300</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#808080">22300</tspan><tspan
+       y="649.45648"
+       x="678.52185"
+       sodipodi:role="line"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:Aller;-inkscape-font-specification:Aller;fill:#b3b3b3"
+       id="tspan3933">1y 40d</tspan></text>
   <text
      inkscape:transform-center-y="39.14128"
      xml:space="preserve"
@@ -3505,7 +3535,7 @@
       </g>
       <g
          id="g138"
-         enable-background="new    ">
+         enable-background="new ">
         <path
            style="fill:#ffffff"
            id="path140"
@@ -3519,7 +3549,7 @@
       </g>
       <g
          id="g144"
-         enable-background="new    ">
+         enable-background="new ">
         <path
            style="fill:#ffffff"
            id="path146"
@@ -3533,7 +3563,7 @@
       </g>
       <g
          id="g150"
-         enable-background="new    ">
+         enable-background="new ">
         <path
            style="fill:#ffffff"
            id="path152"
@@ -3671,7 +3701,7 @@
              y="34.16898"
              style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Normal';text-align:justify;writing-mode:lr-tb;text-anchor:start" /></flowRegion><flowPara
            id="flowPara4871"
-           style="-inkscape-font-specification:Aller;font-family:Aller;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal">Low orbits are 10 km above atmosphere or terrain obstacles. All values are measured as vacuum Δv in m/s. Total values do not include maximum plane change Δv. Atmospheric ascent values are typical. More/less efficient ascents are likely, depending on ascent profile, TWR and aerodynamic effects. Flight time is based on 10 years of average flight possibilities simulated on AlexMoon's Launch Window Planner, from day 1.  </flowPara><flowPara
+           style="-inkscape-font-specification:Aller;font-family:Aller;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal">Low orbits are 10 km above atmosphere or terrain obstacles. All values are measured as vacuum Δv in m/s. Total values do not include maximum plane change Δv. Atmospheric ascent values are typical. More/less efficient ascents are likely, depending on ascent profile, TWR and aerodynamic effects. Flight time is based on 10 years of average flight possibilities simulated on AlexMoon's Launch Window Planner, from day 1. </flowPara><flowPara
            id="flowPara4875"
            style="-inkscape-font-specification:Aller;font-family:Aller;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal" /><flowPara
            id="flowPara4877"
@@ -3736,7 +3766,7 @@
            inkscape:connector-curvature="0" />
         <path
            style="opacity:1;fill:#b4d157;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m -397.0798,503.69862 -11.51206,0.36362 c 0,0 0.50202,0.66519 -0.84294,1.97197 -0.71055,0.76683 -2.1964,1.32054 -4.30363,1.44025 0,0 0,0 0,0 -3.53503,0.13107 -7.65792,-1.35544 -12.12699,-4.3216 -4.26712,-2.9457 -8.12509,-7.22519 -10.68726,-12.48735 -2.29313,-4.80303 -4.21454,-9.67025 -5.01845,-14.65221 -0.5099,-4.16693 -0.67133,-8.08848 1.22746,-10.63113 1.23811,-1.78309 2.79366,-3.21717 4.52587,-3.73402 1.51312,-0.52098 3.26045,-0.44504 4.75131,0.0749 1.56209,0.56223 2.89579,1.5505 3.72105,2.75849 0.9049,1.29301 1.22146,2.89155 0.95445,4.21274 -0.3117,1.38221 -0.74137,2.44948 -1.46127,3.17134 -0.54698,0.66267 -1.35381,1.05763 -2.06593,1.26047 -2.12017,0.0253 -3.4629,0.15248 -3.558,0.43719 0,0 0,0 0,0 0,0 0,0 0,0 0,0 0,0 0,0 -0.002,0.007 -0.002,0.007 -0.002,0.007 0,0 -5e-5,-1e-5 -0.002,0.007 0,0 0,10e-6 0,10e-6 0,0 0,0 0,0 0,0 0,0 0,0 -0.056,0.2905 1.14538,0.739 3.55323,1.33993 1.0443,-0.001 2.38134,-0.26783 3.66862,-1.11944 1.31706,-0.96145 2.37194,-2.41893 2.98347,-4.18955 0.74079,-2.11727 0.70319,-4.74495 -0.55918,-7.17144 -1.10495,-2.10615 -2.94226,-3.95081 -5.33363,-5.09988 -2.32704,-1.13325 -5.14646,-1.58578 -8.01725,-0.97283 -3.2325,0.76726 -6.08768,2.69631 -8.12944,5.31371 -3.35078,4.49994 -4.13994,10.14376 -3.51616,15.22573 0.54829,6.05022 2.29094,11.82451 4.47572,17.19604 2.78098,6.87886 7.30369,12.64084 12.67023,16.86854 5.39817,4.37911 11.52855,6.76367 17.62431,7.18319 0,0 10e-6,0 10e-6,0 4.52205,0.31602 8.5411,-1.19211 11.56947,-3.40936 6.44886,-4.94604 5.41055,-11.04285 5.41055,-11.04285 z"
+           d="m -397.0798,503.69862 -11.51206,0.36362 c 0,0 0.50202,0.66519 -0.84294,1.97197 l 0,0 c -0.71055,0.76683 -2.1964,1.32054 -4.30363,1.44025 l 0,0 0,0 0,0 c -3.53504,0.13107 -7.65792,-1.35544 -12.12699,-4.3216 -4.26713,-2.9457 -8.12509,-7.22518 -10.68726,-12.48734 -2.29314,-4.80304 -4.21454,-9.67026 -5.01846,-14.65222 -0.50989,-4.16694 -0.67133,-8.08849 1.22746,-10.63114 l 0,0 c 1.23811,-1.78309 2.79366,-3.21717 4.52587,-3.73402 l 0,0 c 1.51313,-0.52099 3.26046,-0.44504 4.75133,0.0749 l 0,0 c 1.56209,0.56223 2.8958,1.5505 3.72105,2.75849 l 0,0 c 0.90491,1.29302 1.22147,2.89157 0.95446,4.21275 l 0,0 c -0.3117,1.38223 -0.74137,2.44949 -1.46127,3.17136 l 0,0 c -0.60398,0.66038 -1.44567,1.05377 -2.17486,1.25597 l 0,0 c -0.85456,0.23461 -1.7241,0.25982 -2.27459,0.27354 l 0,0 c -0.33606,0.008 -0.60588,0.0113 -0.80108,0.0308 l 0,0 0,0 c -0.10179,0.011 -0.18512,0.0266 -0.24703,0.0482 l 0,0 c -0.0485,0.0508 -0.0799,0.075 -0.0995,0.0864 -0.0193,0.0112 -0.0274,0.01 -0.0286,0.01 0,0 0,0 0,0 0,0 0,0 0,0 -1.4e-4,-4e-5 -1.2e-4,-3e-5 -1.2e-4,-3e-5 0,0 -2e-5,-1e-5 10e-5,6e-5 0,0 0,0 0,0 0,0 0,0 0,0 0.001,6e-4 0.008,0.005 0.0146,0.0266 0.007,0.0217 0.0138,0.0605 0.0159,0.12986 l 0,1e-5 c 0.0361,0.058 0.0972,0.12379 0.18458,0.19616 l 0,0 0,0 c 0.16005,0.13406 0.41059,0.29044 0.7523,0.44406 l 0,0 c 0.57016,0.25752 1.50984,0.55494 2.69294,0.55452 l 0,0 c 1.02736,-0.002 2.32925,-0.26999 3.55969,-1.12395 l 0,0 c 1.31705,-0.96144 2.37194,-2.41891 2.98347,-4.18953 l 0,0 c 0.74079,-2.11726 0.7032,-4.74494 -0.55917,-7.17143 l 0,0 c -1.10495,-2.10615 -2.94226,-3.9508 -5.33363,-5.09988 l 0,0 c -2.32703,-1.13324 -5.14645,-1.58578 -8.01724,-0.97283 -3.23249,0.76726 -6.08767,2.69631 -8.12943,5.3137 l 0,0 c -3.35078,4.49994 -4.13995,10.14376 -3.51616,15.22573 0.54828,6.05021 2.29094,11.8245 4.47571,17.19604 2.78098,6.87885 7.30369,12.64084 12.67024,16.86853 5.39816,4.37912 11.52854,6.76368 17.6243,7.1832 l 0,0 c 0,0 10e-6,0 10e-6,0 4.52205,0.31602 8.5411,-1.19211 11.56947,-3.40936 l 0,0 c 6.44886,-4.94604 5.41055,-11.04285 5.41055,-11.04285 z"
            id="path4576"
            inkscape:connector-curvature="0"
            inkscape:path-effect="#path-effect4242-6-5-2"


### PR DESCRIPTION
SKETCH: Added Time between transfer windows to return to Kerbin:
- This is the average time between transfer windows from a planet to Kerbin. This data is useful for those who use life support mods, so they know how long they'll have to survive in a planet before the next window to return home.
- This is a sketch. I just placed the raw data there; if you can find a better place/method to show this data, feel free to modify as you see fit.

Reduced 1K from the Eve-to-Orbit dV.
